### PR TITLE
JIT-35959 : fix(agent-group): move from +UseContainerSupport to Xms/Xmx

### DIFF
--- a/charts/agent-group/Chart.yaml
+++ b/charts/agent-group/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: agent-group
-version: 1.0.3
+version: 1.0.4
 appVersion: 10
 description: Jitterbit Agent Group
 home: https://github.com/jitterbit/charts

--- a/charts/agent-group/values.yaml
+++ b/charts/agent-group/values.yaml
@@ -79,7 +79,7 @@ affinity:
               release: "{{ .Release.Name }}"
 
 # env is a list of extra environment variables that may be specified in the container
-env:
+env: []
 #  - name: CATALINA_OPTS
 #    value: -Xms512m -Xmx1024m
 #  - name: ENV_VAR_NAME

--- a/charts/agent-group/values.yaml
+++ b/charts/agent-group/values.yaml
@@ -80,8 +80,8 @@ affinity:
 
 # env is a list of extra environment variables that may be specified in the container
 env:
-  - name: CATALINA_OPTS
-    value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+#  - name: CATALINA_OPTS
+#    value: -Xms512m -Xmx1024m
 #  - name: ENV_VAR_NAME
 #    value: "ENV_VAR_VALUE"
 #  - name: SECRET_PASSWORD


### PR DESCRIPTION
Moving from [`+UseContainerSupport`](https://www.eclipse.org/openj9/docs/xxusecontainersupport/) to `-Xms`/`-Xmx` for JVM heap configuration by default. `-Xms512m -Xmx1024m` is the new default used by the Docker Agent's Dockerfile (the Debian Agent's default). It can be overridden by setting an `env[]` item in the values file like:
```yaml
env:
  - name: CATALINA_OPTS
    value: -Xms1g -Xmx2g
```

FYI, `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` is just the back-ported Java 8 nomenclature for Java 10+'s `+UseContainerSupport`.

JIRA: [JIT-35959](https://jitterbit.atlassian.net/browse/JIT-35959)