### PR TITLE
JIT-35959: feat(agent-group): make readiness and liveness probes configurable

### DIFF
--- a/charts/agent-group/Chart.yaml
+++ b/charts/agent-group/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: agent-group
-version: 1.0.4
+version: 1.0.5
 appVersion: 10
 description: Jitterbit Agent Group
 home: https://github.com/jitterbit/charts

--- a/charts/agent-group/templates/_required.tpl
+++ b/charts/agent-group/templates/_required.tpl
@@ -19,4 +19,6 @@
   {{- required "resources is required!" .Values.resources -}}
   {{- required "revisionHistoryLimit is required!" .Values.revisionHistoryLimit -}}
   {{- required "affinity is required!" .Values.affinity -}}
+  {{- required "readinessProbe is required!" .Values.readinessProbe -}}
+  {{- required "livenessProbe is required!" .Values.livenessProbe -}}
 {{- end -}}

--- a/charts/agent-group/templates/statefulset.yaml
+++ b/charts/agent-group/templates/statefulset.yaml
@@ -58,17 +58,10 @@ spec:
           env:
             {{- toYaml .Values.env | trimSuffix "\n" | nindent 12 }}
           {{- end }}
-          readinessProbe: &probe
-            httpGet:
-              scheme: HTTP
-              port: http-healthz
-              path: /
-            initialDelaySeconds: 90
-            periodSeconds: 30
-            timeoutSeconds: 5
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | trimSuffix "\n" | nindent 12 }}
           livenessProbe:
-            <<: *probe
-            initialDelaySeconds: 300
+            {{- toYaml .Values.livenessProbe | trimSuffix "\n" | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | trimSuffix "\n" | nindent 12 }}
           volumeMounts:

--- a/charts/agent-group/values.schema.yaml
+++ b/charts/agent-group/values.schema.yaml
@@ -11,6 +11,8 @@ required:
   - resources
   - revisionHistoryLimit
   - affinity
+  - readinessProbe
+  - livenessProbe
   - env
 properties:
   metadata:
@@ -91,6 +93,18 @@ properties:
   affinity:
     description: Pod affinity and anti-affinity definitions
     $ref: "#/definitions/affinity"
+  readinessProbe:
+    description: >
+      Periodic probe of container service readiness.
+      Container will be removed from service endpoints if the probe fails.
+      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+    $ref: "#/definitions/probe"
+  livenessProbe:
+    description: >
+      Periodic probe of container liveness.
+      Container will be restarted if the probe fails.
+      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+    $ref: "#/definitions/probe"
   env:
     description: List of additional environment variables that may be specified in the container
     $ref: "#/definitions/env"

--- a/charts/agent-group/values.yaml
+++ b/charts/agent-group/values.yaml
@@ -78,6 +78,7 @@ affinity:
               app: '{{ template "agent-group.name" . }}'
               release: "{{ .Release.Name }}"
 
+# readinessProbe is the container's readinessProbe definition
 readinessProbe:
   httpGet:
     scheme: HTTP
@@ -86,6 +87,8 @@ readinessProbe:
   initialDelaySeconds: 90
   periodSeconds: 30
   timeoutSeconds: 5
+
+# livenessProbe is the container's livenessProbe definition
 livenessProbe:
   httpGet:
     scheme: HTTP

--- a/charts/agent-group/values.yaml
+++ b/charts/agent-group/values.yaml
@@ -78,6 +78,23 @@ affinity:
               app: '{{ template "agent-group.name" . }}'
               release: "{{ .Release.Name }}"
 
+readinessProbe:
+  httpGet:
+    scheme: HTTP
+    port: http-healthz
+    path: /
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 5
+livenessProbe:
+  httpGet:
+    scheme: HTTP
+    port: http-healthz
+    path: /
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  timeoutSeconds: 5
+
 # env is a list of extra environment variables that may be specified in the container
 env: []
 #  - name: CATALINA_OPTS

--- a/definitions.schema.yaml
+++ b/definitions.schema.yaml
@@ -89,6 +89,9 @@ definitions:
   affinity:
     description: Pod affinity and anti-affinity definitions
     $ref: "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.12.8-standalone-strict/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"
+  probe:
+    description: Container's readiness and liveness probe definition
+    $ref: "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.12.8-standalone-strict/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
   env:
     description: List of additional environment variables that may be specified in the container
     type: array


### PR DESCRIPTION
`readinessProbe` and `livenessProbe` are now configurable via the values file.

JIRA: [JIT-35959](https://jitterbit.atlassian.net/browse/JIT-35959)