### PR TITLE
Added name override parameter

### DIFF
--- a/charts/dockerconfigjson/values.schema.yaml
+++ b/charts/dockerconfigjson/values.schema.yaml
@@ -6,6 +6,9 @@ additionalProperties: false
 required:
   - imageCredentials
 properties:
+  nameOverride:
+    description: The nameOverride parameter used change name of secret created
+    type: string
   imageCredentials:
     description: List of .dockerconfigjson configurations
     type: array


### PR DESCRIPTION
Because the nameOverride parameter is not in the scheam, you cannot provide that setting to the chart.

```
==> Linting ./dockerconfigjson-orig-1.0.0.tgz
[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
dockerconfigjson:
- (root): Additional property nameOverride is not allowed
```

This chart is handy for defining several docker auth configs at once and works with helmfile/the rest of our automation. In our environments we need to change the name of secret created.