### PR TITLE
Token support

### DIFF
--- a/charts/agent-group/templates/_required.tpl
+++ b/charts/agent-group/templates/_required.tpl
@@ -11,8 +11,13 @@
   {{- required "agent is required!" .Values.agent -}}
     {{- required "agent.registerjson is required!" .Values.agent.registerjson -}}
       {{- required ".Values.agent.registerjson.cloudUrl is required!" .Values.agent.registerjson.cloudUrl -}}
-      {{- required ".Values.agent.registerjson.username is required!" .Values.agent.registerjson.username -}}
-      {{- required ".Values.agent.registerjson.password is required!" .Values.agent.registerjson.password -}}
+      {{- if not .Values.agent.registerjson.token -}}
+        {{- required ".Values.agent.registerjson.username is required when token is not provided!" .Values.agent.registerjson.username -}}
+        {{- required ".Values.agent.registerjson.password is required when token is not provided!" .Values.agent.registerjson.password -}}
+      {{- end -}}
+      {{- if not (or .Values.agent.registerjson.username .Values.agent.registerjson.password) -}}
+        {{- required ".Values.agent.registerjson.token is required when username and password are not provided!" .Values.agent.registerjson.token -}}
+      {{- end -}}
       {{- required ".Values.agent.registerjson.agentGroupId is required!" .Values.agent.registerjson.agentGroupId -}}
   {{- required "hpa is required!" .Values.hpa -}}
   {{- required "replicas is required!" .Values.replicas -}}

--- a/charts/agent-group/values.yaml
+++ b/charts/agent-group/values.yaml
@@ -16,6 +16,7 @@ agent:
 #    cloudUrl: https://na-east.jitterbit.com
 #    username: $00lAuva91/rNxAaoQ+bC3pdtq+dXD9CLw9YdFGxcHLXI3Fhgf6JXQp3dDnIVKZE89xzwREjV/KDqINtTr8XQ/w==
 #    password: $00RIOD/BqGlQ1ack56p2GKG8vXJlpfAnbLxyUs5GqH8=
+#    token: xx_xx_xxxxx  # (optional if username and password are not provided)
 #    agentGroupId: 6282
 #    agentNamePrefix: "%host%"
 #    deregisterAgentOnDrainstop: true


### PR DESCRIPTION
Currently the official Helm chart doesn’t support authentication using only a token. 
 
It’s currently hard‑coded to use a username and password, and there’s no option to supply just a token.

```
helm upgrade --install agent-group .
Error: UPGRADE FAILED: execution error at (agent-group/templates/NOTES.txt:22:7): .Values.agent.registerjson.username is required!
```
 
This PR is adding the feature to support Token as well.