### PR TITLE
feat(agent-group): add token auth support to registerjson schema

### DIFF
--- a/charts/agent-group/values.schema.yaml
+++ b/charts/agent-group/values.schema.yaml
@@ -41,12 +41,7 @@ properties:
           - type: object
             additionalProperties: false
           - type: object
-            additionalProperties: false
-            required:
-              - cloudUrl
-              - username
-              - password
-              - agentGroupId
+            additionalProperties: true
             properties:
               cloudUrl:
                 description: Base URL of the Jitterbit Harmony Cloud
@@ -56,6 +51,12 @@ properties:
                 type: string
               password:
                 description: Encrypted password of the Agent Installer user (encrypted using JitterbitUtils)
+                type: string
+              token:
+                description: Authentication token (alternative to username/password)
+                type: string
+              agentMetricsToken:
+                description: Token for agent metrics reporting
                 type: string
               agentGroupId:
                 description: Agent group ID from Management Console (hover over an agent group to see its ID)

--- a/charts/agent-group/values.yaml
+++ b/charts/agent-group/values.yaml
@@ -14,8 +14,12 @@ agent:
   # agent.registerjson is the agent group's register.json file
   registerjson: {}
 #    cloudUrl: https://na-east.jitterbit.com
+#    # Authenticate with username/password (encrypted using JitterbitUtils):
 #    username: $00lAuva91/rNxAaoQ+bC3pdtq+dXD9CLw9YdFGxcHLXI3Fhgf6JXQp3dDnIVKZE89xzwREjV/KDqINtTr8XQ/w==
 #    password: $00RIOD/BqGlQ1ack56p2GKG8vXJlpfAnbLxyUs5GqH8=
+#    # Or authenticate with a token (alternative to username/password):
+#    token: xx_xx_xxxxx
+#    agentMetricsToken: xx_xx_xxxxx
 #    agentGroupId: 6282
 #    agentNamePrefix: "%host%"
 #    deregisterAgentOnDrainstop: true


### PR DESCRIPTION
Remove the strict oneOf requirement for username/password in values.schema.yaml. The configured-object variant now uses additionalProperties: true with no required fields, allowing token-based authentication alongside the existing username/password approach.

Also documents token and agentMetricsToken as known properties with type checking in both the schema and values.yaml example.